### PR TITLE
Add ci flow for GH actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9
+        uses: styfle/cancel-workflow-action@0.9.1
 
       - name: ⬇️ Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR introduces only `ci` flow for running tests on every `push` and `pull_request` events.

The rest of the functionality will follow later.