### PR TITLE
feat(uischema): add support for complex js types in uischema

### DIFF
--- a/packages/core/src/models/UISchema/accessors/base-accessor.ts
+++ b/packages/core/src/models/UISchema/accessors/base-accessor.ts
@@ -1,3 +1,5 @@
+import cloneDeep from 'lodash/cloneDeep';
+
 import {ComponentOptions, UIHints, UISchema} from '../..';
 
 export interface BaseAccessorInterface {
@@ -22,7 +24,7 @@ export class BaseAccessor implements BaseAccessorInterface {
     protected uiSchemaClone: UISchema;
 
     constructor(protected uiSchema: UISchema, protected path: string) {
-        this.uiSchemaClone = JSON.parse(JSON.stringify(uiSchema));
+        this.uiSchemaClone = cloneDeep(uiSchema);
     }
 
     public get() {

--- a/packages/core/tests/ui-schema/base-accessor-contract.ts
+++ b/packages/core/tests/ui-schema/base-accessor-contract.ts
@@ -263,5 +263,66 @@ export function runBaseAccessorContract(
                 ).not.toBeUndefined();
             });
         });
+
+        describe('immutability', () => {
+            const uiSchema: UISchema = {
+                hints: {
+                    [DEFAULT_PATH]: {
+                        uiGroups: [
+                            {
+                                name: GROUP_NAMES.A,
+                                title: TITLE_PLACEHOLDER,
+                                fields: [
+                                    FIELD_NAME_PLACEHOLDER,
+                                    FIELD_NAME_PLACEHOLDER + 1
+                                ]
+                            }
+                        ],
+                        order: [
+                            FIELD_NAME_PLACEHOLDER,
+                            FIELD_NAME_PLACEHOLDER + 1
+                        ]
+                    }
+                },
+                components: {
+                    [REPO_NAME_PLACEHOLDER]: {
+                        [DEFAULT_PATH]: {
+                            name: COMPONENT_NAME_PLACEHOLDER,
+                            options: {foo: 'bar', baz: () => ({abc: 'xyz'})}
+                        }
+                    }
+                }
+            };
+
+            beforeEach(() => {
+                uiSchemaEntity = getAccessor(uiSchema);
+            });
+
+            it('should preserve non-json types', () => {
+                const {options} = uiSchemaEntity.getComponentOptions(
+                    REPO_NAME_PLACEHOLDER
+                )!;
+
+                expect(typeof options.baz).toBe('function');
+                expect(options.baz()).toEqual({abc: 'xyz'});
+            });
+
+            it('constructor clones uiSchema', () => {
+                uiSchemaEntity.setComponentOptions(
+                    REPO_NAME_PLACEHOLDER,
+                    () => ({
+                        name: COMPONENT_NAME_PLACEHOLDER,
+                        options: {foo: 'baz'}
+                    })
+                );
+
+                const {options} = uiSchemaEntity.getComponentOptions(
+                    REPO_NAME_PLACEHOLDER
+                )!;
+
+                expect(options.foo).toEqual('baz');
+                expect(uiSchema.components[REPO_NAME_PLACEHOLDER][DEFAULT_PATH].options.foo).toEqual('bar');
+            });
+        });
     });
 }


### PR DESCRIPTION
UISchema no longer use JSON.stringify/JSON.parse for cloning; use lodash/deepClone instead

BREAKING CHANGE: UISchema supports more types

## Summary

Now UISchema can contain not only JS primitives, but also complex types like functions

## How did you test this change?

Added coverage within tests
