### PR TITLE
feat(schema): added `prefixItems` support as tuple

### DIFF
--- a/packages/core/src/auto-view/default-items.tsx
+++ b/packages/core/src/auto-view/default-items.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import {buildJsonPointer} from '../utils';
+import {CoreSchemaMetaSchema} from '../models';
 
 import {AutoView, AutoViewProps} from './auto-view';
 import {filter, getHints, orderFields} from './utils';
-
 export interface AutoFieldsProps extends AutoViewProps {
     render?(
         item: React.ReactNode,
@@ -80,7 +80,7 @@ export const AutoFields: React.FunctionComponent<AutoFieldsProps> = ({
     render = (a: React.ReactNode) => a,
     ...props
 }) => (
-    <React.Fragment>
+    <>
         {autoFieldsProps(props).map(fieldProps => {
             return render(
                 <AutoView
@@ -91,7 +91,7 @@ export const AutoFields: React.FunctionComponent<AutoFieldsProps> = ({
                 fieldProps.field
             );
         })}
-    </React.Fragment>
+    </>
 );
 
 export type AutoItemsProps = {
@@ -103,7 +103,7 @@ export type AutoItemsProps = {
 } & AutoViewProps;
 
 export const AutoItems = ({render = a => a, ...props}: AutoItemsProps) => (
-    <React.Fragment>
+    <>
         {autoItemsProps(props).map((itemProps, index) =>
             render(
                 <AutoView
@@ -114,11 +114,21 @@ export const AutoItems = ({render = a => a, ...props}: AutoItemsProps) => (
                 index
             )
         )}
-    </React.Fragment>
+    </>
 );
 
+const ensureArrayData = (data: any, schema: CoreSchemaMetaSchema): any[] => {
+    if (data && Array.isArray(data)) {
+        return data;
+    }
+
+    return Array.isArray(schema.prefixItems)
+        ? new Array(schema.prefixItems.length).fill(undefined)
+        : [];
+};
+
 export function autoItemsProps({
-    data = [],
+    data,
     metadata,
     schema,
     uiSchema,
@@ -130,8 +140,8 @@ export function autoItemsProps({
     onRenderError,
     onCustomEvent
 }: AutoViewProps): AutoViewProps[] {
-    return (data as any[]).map((item, i) => ({
-        schema: nextSchema(schema),
+    return ensureArrayData(data, schema).map((item, i) => ({
+        schema: nextSchema(schema, i),
         data: item,
         metadata,
         uiSchema,
@@ -146,12 +156,30 @@ export function autoItemsProps({
     }));
 }
 
+const findPrefixMatch = (
+    prefixItems?: AutoViewProps['schema']['prefixItems'],
+    index?: number | string
+) => {
+    if (
+        Array.isArray(prefixItems) &&
+        typeof index === 'number' &&
+        prefixItems[index]
+    ) {
+        return prefixItems[index];
+    }
+};
+
 export function nextSchema(
     schema: AutoViewProps['schema'],
-    dataPointer?: string
+    dataPointer?: string | number
 ): AutoViewProps['schema'] {
     if (schema.type === 'array') {
-        return schema.items || [];
+        return (
+            findPrefixMatch(schema.prefixItems, dataPointer) ??
+            schema.items ??
+            schema.additionalItems ??
+            []
+        );
     }
 
     if (dataPointer !== undefined && schema.type === 'object') {
@@ -162,6 +190,7 @@ export function nextSchema(
                 : {};
         return properties[dataPointer] ?? additional;
     }
+
     throw Error('array schema or object schema and dataPointer expected');
 }
 
@@ -183,6 +212,6 @@ export function buildNextSchemaPointer(
     throw Error('object or array schema expected');
 }
 
-export const AnyData: React.SFC<AutoViewProps> = props => (
+export const AnyData: React.FunctionComponent<AutoViewProps> = props => (
     <pre>{JSON.stringify(props.data, null, 4)}</pre>
 );

--- a/packages/core/src/models/JSONSchema/JSONSchema.ts
+++ b/packages/core/src/models/JSONSchema/JSONSchema.ts
@@ -28,7 +28,8 @@ export interface CoreSchemaMetaSchema {
     minLength?: NonNegativeIntegerDefault0;
     pattern?: string;
     additionalItems?: CoreSchemaMetaSchema;
-    items?: CoreSchemaMetaSchema | SchemaArray;
+    items?: CoreSchemaMetaSchema;
+    prefixItems?: SchemaArray;
     maxItems?: NonNegativeInteger;
     minItems?: NonNegativeIntegerDefault0;
     uniqueItems?: boolean;

--- a/packages/core/tests/auto-view/auto-view.test.tsx
+++ b/packages/core/tests/auto-view/auto-view.test.tsx
@@ -577,6 +577,136 @@ describe('AutoView', () => {
                 expect(field12).toBeInTheDocument();
                 expect(field12).toHaveValue('1-2');
             });
+
+            describe('tuple', () => {
+                it('should render fieldset with empty string as default value', () => {
+                    render(
+                        <RepositoryProvider components={components}>
+                            <AutoView
+                                schema={{
+                                    type: 'array',
+                                    prefixItems: [{type: 'string'}]
+                                }}
+                            />
+                        </RepositoryProvider>
+                    );
+
+                    const fieldset = screen.getByTestId('#FIELDSET');
+                    const input = within(fieldset).queryByTestId(
+                        '/0#NATIVE_TEXT_INPUT'
+                    );
+
+                    expect(fieldset).toBeInTheDocument();
+                    expect(input).toHaveValue('');
+                });
+
+                it('should render a fieldset without data', () => {
+                    render(
+                        <RepositoryProvider components={components}>
+                            <AutoView
+                                schema={{
+                                    type: 'array',
+                                    prefixItems: [
+                                        {type: 'string'},
+                                        {
+                                            type: 'object',
+                                            properties: {
+                                                field1: {type: 'string'},
+                                                inner: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        field2: {type: 'string'}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }}
+                            />
+                        </RepositoryProvider>
+                    );
+
+                    const fieldset = screen.getByTestId('#FIELDSET');
+
+                    const field01 = within(fieldset).getByTestId(
+                        '/0#NATIVE_TEXT_INPUT'
+                    );
+                    const field11 = within(fieldset).getByTestId(
+                        '/1/field1#NATIVE_TEXT_INPUT'
+                    );
+                    const field12 = within(fieldset).getByTestId(
+                        '/1/inner/field2#NATIVE_TEXT_INPUT'
+                    );
+
+                    expect(fieldset).toBeInTheDocument();
+
+                    expect(field01).toBeInTheDocument();
+                    expect(field01).toHaveValue('');
+
+                    expect(field11).toBeInTheDocument();
+                    expect(field11).toHaveValue('');
+
+                    expect(field12).toBeInTheDocument();
+                    expect(field12).toHaveValue('');
+                });
+
+                it('should render a fieldset with data', () => {
+                    render(
+                        <RepositoryProvider components={components}>
+                            <AutoView
+                                schema={{
+                                    type: 'array',
+                                    prefixItems: [
+                                        {type: 'string'},
+                                        {
+                                            type: 'object',
+                                            properties: {
+                                                field1: {type: 'string'},
+                                                inner: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        field2: {type: 'string'}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }}
+                                data={[
+                                    '0-1',
+                                    {
+                                        field1: '1-1',
+                                        inner: {field2: '1-2'}
+                                    }
+                                ]}
+                            />
+                        </RepositoryProvider>
+                    );
+
+                    const fieldset = screen.getByTestId('#FIELDSET');
+
+                    const field01 = within(fieldset).getByTestId(
+                        '/0#NATIVE_TEXT_INPUT'
+                    );
+                    const field11 = within(fieldset).getByTestId(
+                        '/1/field1#NATIVE_TEXT_INPUT'
+                    );
+                    const field12 = within(fieldset).getByTestId(
+                        '/1/inner/field2#NATIVE_TEXT_INPUT'
+                    );
+
+                    expect(fieldset).toBeInTheDocument();
+
+                    expect(field01).toBeInTheDocument();
+                    expect(field01).toHaveValue('0-1');
+
+                    expect(field11).toBeInTheDocument();
+                    expect(field11).toHaveValue('1-1');
+
+                    expect(field12).toBeInTheDocument();
+                    expect(field12).toHaveValue('1-2');
+                });
+            });
         });
 
         describe('multiple types', () => {


### PR DESCRIPTION
## Summary

Now it is possible to render tuple defined in `prefixItems`. It affected `CoreSchemaMetaSchema` type
with adding `prefixItems` and narrowing `items` types.

BREAKING CHANGE: `CoreSchemaMetaSchema['items']` now just has `CoreSchemaMetaSchema` type,
nextSchema function now consider this field

closes #90


## How did you test this change?

added tests 