### PR TITLE
Extended predicate interface with AutoViewProps

### DIFF
--- a/packages/core/src/auto-view/auto-view.tsx
+++ b/packages/core/src/auto-view/auto-view.tsx
@@ -93,7 +93,7 @@ class AutoViewLogic extends React.Component<AutoViewLogicProps> {
         if (!type) {
             throw new Error(`type is not set "${schemaPointer}"`);
         }
-        const matches = components.getMatched(schema);
+        const matches = components.getMatched(schema, this.props);
         const dataOrDefault =
             data === undefined || data === null ? schema.default : data;
 

--- a/packages/core/src/repository/components-repo.ts
+++ b/packages/core/src/repository/components-repo.ts
@@ -16,7 +16,11 @@ export interface ComponentsRepoStorage<P> {
     [type: string]: Array<ComponentRepoRecord<P>>;
 }
 
-export type Predicate = (node: CoreSchemaMetaSchema, ...rest: any[]) => boolean;
+export type Predicate = (
+    node: CoreSchemaMetaSchema,
+    props?: AutoViewProps,
+    ...rest: any[]
+) => boolean;
 
 export interface IncludeExcludeRules {
     include?: string[];
@@ -167,7 +171,7 @@ export class ComponentsRepo {
         }
     }
 
-    public getMatched(node: CoreSchemaMetaSchema) {
+    public getMatched(node: CoreSchemaMetaSchema, props?: AutoViewProps) {
         const type = this.getNodeType(node);
 
         if (typeof type !== 'string') {
@@ -176,7 +180,9 @@ export class ComponentsRepo {
         const registered = this.getByType(type) || [];
         // noinspection JSUnusedLocalSymbols
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        return registered.filter(({predicate = n => true}) => predicate(node));
+        return registered.filter(({predicate = n => true}) =>
+            predicate(node, props)
+        );
     }
 
     public registerCollection(

--- a/packages/core/tests/auto-view/auto-view.test.tsx
+++ b/packages/core/tests/auto-view/auto-view.test.tsx
@@ -1417,4 +1417,53 @@ describe('AutoView', () => {
             expect(input).toHaveAttribute('readonly');
         });
     });
+
+    describe('predicate with props', () => {
+        it('should omit component with false predicate and pick with true', () => {
+            const components = new ComponentsRepo('test')
+                .register('object', {name: 'MyObject', component: AutoFields})
+                .register('string', {
+                    name: 'MyString-1',
+                    component: props => (
+                        <span data-automation-id={`${props.schemaPointer}-1`} />
+                    )
+                })
+                .register('string', {
+                    name: 'MyString-2',
+                    component: props => (
+                        <span data-automation-id={`${props.schemaPointer}-2`} />
+                    ),
+                    predicate: (node, props) =>
+                        props?.schemaPointer === '/properties/a'
+                })
+                .register('string', {
+                    name: 'MyString-3',
+                    component: props => (
+                        <span data-automation-id={`${props.schemaPointer}-3`} />
+                    ),
+                    predicate: (node, props) =>
+                        Boolean(props?.metadata?.alwaysFalse)
+                });
+
+            const schema: CoreSchemaMetaSchema = {
+                type: 'object',
+                properties: {
+                    a: {type: 'string'}
+                }
+            };
+
+            render(
+                <RepositoryProvider components={components}>
+                    <AutoView
+                        schema={schema}
+                        metadata={{alwaysFalse: false}}
+                    />
+                </RepositoryProvider>
+            );
+
+            const input = screen.getByTestId('/properties/a-2');
+
+            expect(input).toBeInTheDocument();
+        });
+    });
 });

--- a/packages/core/tests/components-repos.test.tsx
+++ b/packages/core/tests/components-repos.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {ComponentsRepo} from '../src';
+import {ComponentsRepo, Predicate} from '../src';
 import {CoreSchemaMetaSchema} from '../src/models';
 
 describe('ComponentsRepo', () => {
@@ -116,6 +116,35 @@ describe('ComponentsRepo', () => {
                 {
                     name: 'component2',
                     predicate: hasMinMax,
+                    component: component2
+                }
+            ]);
+        });
+
+        it('should pass props to predicate', () => {
+            const component1 = () => <span>component1</span>;
+            const component2 = () => <span>component2</span>;
+            const hasSpecialField: Predicate = (n, p) =>
+                Boolean(p?.metadata?.mySpecialField);
+            const repo = new ComponentsRepo('testRepo')
+                .register('number', {
+                    name: 'component1',
+                    predicate: hasSpecialField,
+                    component: component1
+                })
+                .register('number', {
+                    name: 'component2',
+                    component: component2
+                });
+
+            const result = repo.getMatched(
+                {type: 'number'},
+                {metadata: {mySpecialField: false}, schema: {type: 'number'}}
+            );
+
+            expect(result).toEqual([
+                {
+                    name: 'component2',
                     component: component2
                 }
             ]);

--- a/packages/website/docs/entities/components-repo.md
+++ b/packages/website/docs/entities/components-repo.md
@@ -130,22 +130,37 @@ myRepo.register('user', {
 Multiple components can be registered for the same data type. When registering multiple components, by default, the last registered component will be selected.
 
 Registering multiple components allows selecting components using predicates or [UISchema](/docs/entities/ui-schema).
+
 Predicates are used when the condition is computed on the JSONSchema, such as `maxLength`, `maximum` or `required`. A concrete example is selecting the Slider component when a number has `maximum` and `minimum` constraints.
+
 `UISchema` is used when we want to select a specific component or pass properties to the component on a specific JSONSchema path (`JSONPointer`).
 
 ## Predicates
 
-Predicates are functions defined when registering a component, defining when to use the component based on the JSONSchema.
+Predicates are functions defined when registering a component, defining when to use the component based on the JSONSchema and Component's props.
+
+If predicates returns `true` **and** the current component is the **latest** registred component, it will be used by `AutoViews` (conidering there is no override in [UISchema.components](/docs/entities/ui-schema#the-components-overrides)).
+
+The idea of Predicates is to target special cases only, when you registring components for the same type multiple times.
+
+:::caution
+If you register component without predicate after the one with predicate, component without predicate will be choosen (because it is latest), even if predicate returns `true`.
+:::
 
 The Predicate signature is
 
 ```typescript
-export type Predicate = (node: CoreSchemaMetaSchema) => boolean;
+export type Predicate = (
+  node: CoreSchemaMetaSchema,
+  props?: AutoViewProps,
+  ...rest: any[]
+) => boolean;
 ```
 
 Where
 
 - node: is the JSONSchema node the component is considered for
+- props: is the same `AutoViewProps` object which current component has
 
 ### Example — selecting Slider component for numbers with min & max constraints
 

--- a/packages/website/docs/entities/ui-schema.md
+++ b/packages/website/docs/entities/ui-schema.md
@@ -31,14 +31,15 @@ for rendering. To switch layouts, [replacing a component repository](/docs/entit
 | `compoennts[name: string] [pointer: string].name`    | `string`                 |               | The name of the component to use at the above location, which has to be available in the above component repository                                                  |
 | `compoennts[name: string] [pointer: string].options` | `any`                    |               | Options to pass to the component at the above location                                                                                                               |
 
-## the `components` UI hint
+## the `components` overrides
 
 The `components` field in `UISchema` is responsible for component overrides -
 defining which component `<AutoView/>` should choose for a given field and what `options` this component should get.
 
 By default, `<AutoView/>` picks last component record registered in [the components repository](docs/entities/components-repo#registering-multiple-components-per-jsonschema-data-type) for each type.
 When registering two (or more) components for a specific type, the last one will be used by default.
-The `components` UI hint defines that for a specific [JSONPointer](https://tools.ietf.org/html/rfc6901) in the data `JSONSchema`
+
+The `components` overrides defines that for a specific [JSONPointer](https://tools.ietf.org/html/rfc6901) in the data `JSONSchema`
 a component with specific `name` should be chosen.
 
 ### the getComponentOptions utility
@@ -60,7 +61,7 @@ export const myFunctionalComponent = props => {
 
 ### Example - component override and options
 
-In this example we show how to use the `components` UI Hints to render texts using one of three text components
+In this example we show how to use the `components` overrides to render texts using one of three text components
 
 1. A styled text component, which gets the styles from the component options
 2. A header text component


### PR DESCRIPTION
Now predicate could have and has, if executed in `AutoViews`, `props: AutoViewProps` property, the same as current
component has

fix #108, fix #109

## Summary

This feature allows calculating predicate value not only by the `JSONSchema` leaf value. 

## How did you test this change?

with tests