### PR TITLE
Remove defaultOptions field of ComponentRepoRecord

### DIFF
--- a/packages/core/src/repository/components-repo.ts
+++ b/packages/core/src/repository/components-repo.ts
@@ -38,7 +38,6 @@ export interface ComponentRepoRecord<P> {
     name: string;
     component: React.ComponentType<P>;
     predicate?: Predicate;
-    defaultOptions?: any;
 }
 
 export type ReplaceComponentRepoRecordFn = (

--- a/packages/website/docs/entities/components-repo.md
+++ b/packages/website/docs/entities/components-repo.md
@@ -66,7 +66,6 @@ export interface ComponentRepoRecord<P> {
     name: string;
     component: React.ComponentType<P>;
     predicate?: Predicate;
-    defaultOptions?: any;
 }
 ```
 
@@ -77,7 +76,6 @@ Where
   - `name`: the name of component within the repository, for later reference
   - `component`: the actual component
   - `predicate`: a predicate computed on the schema field, if to use the component for that schema member
-  - `defaultOptions`: option to pass to the component as props. **TBD**
 
 ## The getNodeType constructor parameter
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure you've read Contribution Guidelines:

  https://github.com/wix-incubator/autoviews/blob/master/CONTRIBUTING.md
-->

## Summary

Remove leftovers of defaultOptions in ComponentRepoRecord and corresponding docs

## How did you test this change?

Search across code for usage of this field. Found none
